### PR TITLE
Fix/pytest bdd reporting parametrised tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ version_provider = "pep621"
 update_changelog_on_bump = false
 [project]
 name = "pytestomatio"
-version = "2.10.1b4"
+version = "2.10.1b5"
 
 dependencies = [
     "requests>=2.29.0",

--- a/pytestomatio/testing/testItem.py
+++ b/pytestomatio/testing/testItem.py
@@ -145,11 +145,14 @@ class TestItem:
         if callspec:
             # callspec.params is a dict: fixture_name -> parameter_value
             # We only want fixture names, not the values.
-            param_names.update(callspec.params.keys())
-
+            if self.type == 'bdd':
+                param_names.discard('_pytest_bdd_example')
+                callspec_params = callspec.params.get('_pytest_bdd_example', {})
+                param_names.update(callspec_params.keys())
+            else:
+                param_names.update(callspec.params.keys())
         # Return them as a list, or keep it as a set—whatever you prefer.
         return list(param_names)
-
     
     def _resolve_parameter_key_in_test_name(self, item: Item, test_name: str) -> str:
         test_params = self._get_test_parameter_key(item)
@@ -176,7 +179,8 @@ class TestItem:
 
         def repl(match):
             key = match.group(1)
-            value = item.callspec.params.get(key, '')
+            value = item.callspec.params.get(key, '') if not self.type == 'bdd' else \
+                item.callspec.params.get('_pytest_bdd_example', {}).get(key, '')
             
             string_value = self._to_string_value(value)
             # TODO: handle "value with space" on testomatio BE https://github.com/testomatio/check-tests/issues/147

--- a/tests/test_testing/test_TestItem.py
+++ b/tests/test_testing/test_TestItem.py
@@ -28,6 +28,11 @@ class TestTestItem:
         return item
 
     @pytest.fixture
+    def mock_bdd_item(self, mock_item):
+        mock_item.function.__scenario__ = True
+        return mock_item
+
+    @pytest.fixture
     def mock_item_with_marker(self, mock_item):
         """Mock Item with testomatio marker"""
         marker = Mock()
@@ -182,6 +187,17 @@ class TestTestItem:
 
         assert result == []
 
+    @patch('inspect.getsource')
+    def test_get_test_parameter_key_no_params_for_bdd_test(self, mock_source, mock_bdd_item):
+        """Test _get_test_parameter_key without params for bdd test"""
+        mock_bdd_item.iter_markers.return_value = iter([])
+        test_item = TestItem(mock_bdd_item)
+
+        result = test_item._get_test_parameter_key(mock_bdd_item)
+
+        assert test_item.type == 'bdd'
+        assert result == []
+
     def test_get_test_parameter_key_with_parametrize(self, mock_item):
         """Test _get_test_parameter_key with @pytest.mark.parametrize"""
         param_marker = Mock()
@@ -195,25 +211,51 @@ class TestTestItem:
 
         assert set(result) == {"param1", "param2"}
 
-    def test_get_test_parameter_key_with_callspec(self, mock_item):
+    @patch('inspect.getsource')
+    def test_get_test_parameter_key_with_callspec(self, mock_source, mock_item):
         """Test _get_test_parameter_key with callspec"""
         mock_item.iter_markers.return_value = iter([])
         mock_item.callspec = Mock()
         mock_item.callspec.params = {"fixture1": "value1", "fixture2": "value2"}
 
-        test_item = TestItem.__new__(TestItem)
+        test_item = TestItem(mock_item)
 
         result = test_item._get_test_parameter_key(mock_item)
 
         assert set(result) == {"fixture1", "fixture2"}
 
-    def test_resolve_parameter_key_in_test_name(self, mock_item):
+    @patch('inspect.getsource')
+    def test_get_test_parameter_key_with_callspec_for_bdd_test(self, mock_source, mock_bdd_item):
+        """Test _get_test_parameter_key with callspec for bdd test"""
+        mock_bdd_item.iter_markers.return_value = iter([])
+        mock_bdd_item.callspec = Mock()
+        mock_bdd_item.callspec.params = {'_pytest_bdd_example': {"fixture1": "value1", "fixture2": "value2"}}
+        test_item = TestItem(mock_bdd_item)
+
+        result = test_item._get_test_parameter_key(mock_bdd_item)
+
+        assert test_item.type == 'bdd'
+        assert set(result) == {"fixture1", "fixture2"}
+
+    @patch('inspect.getsource')
+    def test_resolve_parameter_key_in_test_name(self, mock_source, mock_item):
         """Test _resolve_parameter_key_in_test_name"""
-        test_item = TestItem.__new__(TestItem)
+        test_item = TestItem(mock_item)
 
         with patch.object(test_item, '_get_test_parameter_key', return_value=["param1", "param2"]):
             result = test_item._resolve_parameter_key_in_test_name(mock_item, "Test name[value]")
 
+            assert result == "Test name ${param1} ${param2}"
+
+    @patch('inspect.getsource')
+    def test_resolve_parameter_key_in_test_name_for_bdd_test(self, mock_source, mock_bdd_item):
+        """Test _resolve_parameter_key_in_test_name for bdd test"""
+        test_item = TestItem(mock_bdd_item)
+
+        with patch.object(test_item, '_get_test_parameter_key', return_value=["param1", "param2"]):
+            result = test_item._resolve_parameter_key_in_test_name(mock_bdd_item, "Test name[value]")
+
+            assert test_item.type == 'bdd'
             assert result == "Test name ${param1} ${param2}"
 
     def test_resolve_parameter_key_no_params(self, mock_item):
@@ -223,6 +265,17 @@ class TestTestItem:
         with patch.object(test_item, '_get_test_parameter_key', return_value=[]):
             result = test_item._resolve_parameter_key_in_test_name(mock_item, "Test name")
 
+            assert result == "Test name"
+
+    @patch('inspect.getsource')
+    def test_resolve_parameter_key_no_params_for_bdd_test(self, mock_source, mock_bdd_item):
+        """Test _resolve_parameter_key_in_test_name without params for bdd test"""
+        test_item = TestItem(mock_bdd_item)
+
+        with patch.object(test_item, '_get_test_parameter_key', return_value=[]):
+            result = test_item._resolve_parameter_key_in_test_name(mock_bdd_item, "Test name")
+
+            assert test_item.type == 'bdd'
             assert result == "Test name"
 
     def test_to_string_value_various_types(self, mock_item):
@@ -312,9 +365,10 @@ class TestTestItem:
         assert str_result == expected
         assert repr_result == expected
 
-    def test_resolve_parameter_value_in_test_name(self, mock_item):
+    @patch('inspect.getsource')
+    def test_resolve_parameter_value_in_test_name(self, mock_source, mock_item):
         """Test _resolve_parameter_value_in_test_name method"""
-        test_item = TestItem.__new__(TestItem)
+        test_item = TestItem(mock_item)
 
         mock_item.callspec = Mock()
         mock_item.callspec.params = {"param1": "value1", "param2": "value with spaces"}
@@ -323,6 +377,22 @@ class TestTestItem:
             with patch.object(test_item, '_get_sync_test_title', return_value="Test ${param1} and ${param2}"):
                 result = test_item._resolve_parameter_value_in_test_name(mock_item, "Test name")
 
+                assert "value1" in result
+                assert "value_with_spaces" in result
+
+    @patch('inspect.getsource')
+    def test_resolve_parameter_value_in_test_name_for_bdd_test(self, mock_source, mock_bdd_item):
+        """Test _resolve_parameter_value_in_test_name method for bdd test"""
+        test_item = TestItem(mock_bdd_item)
+
+        mock_bdd_item.callspec = Mock()
+        mock_bdd_item.callspec.params = {'_pytest_bdd_example': {"param1": "value1", "param2": "value with spaces"}}
+
+        with patch.object(test_item, '_get_test_parameter_key', return_value=["param1", "param2"]):
+            with patch.object(test_item, '_get_sync_test_title', return_value="Test ${param1} and ${param2}"):
+                result = test_item._resolve_parameter_value_in_test_name(mock_bdd_item, "Test name")
+
+                assert test_item.type == 'bdd'
                 assert "value1" in result
                 assert "value_with_spaces" in result
 

--- a/tests/test_testing/test_TestItem.py
+++ b/tests/test_testing/test_TestItem.py
@@ -225,6 +225,21 @@ class TestTestItem:
         assert set(result) == {"fixture1", "fixture2"}
 
     @patch('inspect.getsource')
+    def test_get_test_parameter_key_keeps_key_order(self, mock_source, mock_item):
+        """Test _get_test_parameter_key keeps key order"""
+        mock_item.iter_markers.return_value = iter([])
+        mock_item.callspec = Mock()
+        mock_item.callspec.params = {"fixture1": "value1", "fixture2": "value2"}
+
+        test_item = TestItem(mock_item)
+
+        result = test_item._get_test_parameter_key(mock_item)
+
+        assert set(result) == {"fixture1", "fixture2"}
+        assert result[0] == 'fixture1'
+        assert result[1] == 'fixture2'
+
+    @patch('inspect.getsource')
     def test_get_test_parameter_key_with_callspec_for_bdd_test(self, mock_source, mock_bdd_item):
         """Test _get_test_parameter_key with callspec for bdd test"""
         mock_bdd_item.iter_markers.return_value = iter([])


### PR DESCRIPTION
Fixed:
 - test id extraction for bdd tests
 - parametrised bdd tests reporting
 - parameter order for parametrised tests